### PR TITLE
Disabled optional as field or parameter Java inspection

### DIFF
--- a/sirius-build/pom.xml
+++ b/sirius-build/pom.xml
@@ -9,7 +9,7 @@
         <version>2.0</version>
     </parent>
     <artifactId>sirius-build</artifactId>
-    <version>2.0</version>
+    <version>2.1</version>
     <packaging>jar</packaging>
 
     <name>Sirius Build Tools</name>

--- a/sirius-build/src/main/resources/.idea/inspectionProfiles/Sirius.xml
+++ b/sirius-build/src/main/resources/.idea/inspectionProfiles/Sirius.xml
@@ -1027,5 +1027,6 @@
       <option name="ADD_SERVLET_TO_ENTRIES" value="true" />
       <option name="ADD_NONJAVA_TO_ENTRIES" value="true" />
     </inspection_tool>
+    <inspection_tool class="OptionalUsedAsFieldOrParameterType" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>


### PR DESCRIPTION
The reason why this is not allowed/desired is questionable:
http://stackoverflow.com/questions/26327957/should-java-8-getters-return-optional-type/26328555#26328555
