### PR TITLE
Changes HTML attribute wrapping mode to "chop down"

### DIFF
--- a/src/main/resources/.idea/codeStyles/Project.xml
+++ b/src/main/resources/.idea/codeStyles/Project.xml
@@ -2,6 +2,7 @@
   <code_scheme name="Project" version="173">
     <option name="WRAP_COMMENTS" value="true" />
     <HTMLCodeStyleSettings>
+      <option name="HTML_ATTRIBUTE_WRAP" value="4" />
       <option name="HTML_KEEP_WHITESPACES_INSIDE" value="span,pre,textarea,k:code,k:mermaid" />
       <option name="HTML_INLINE_ELEMENTS" value="a,abbr,acronym,b,basefont,bdo,big,br,cite,cite,code,dfn,em,font,i,img,input,kbd,label,q,s,samp,select,small,span,strike,strong,sub,sup,textarea,tt,u,var,k:inlineCode,k:lookupTableLink,k:ref,k:link" />
     </HTMLCodeStyleSettings>


### PR DESCRIPTION
This changes the suggested wrapping when auto-formatting overly long tags in HTML.
Note: This does not fix elements that already uses the "Before" step.

**Before:**

![image](https://github.com/scireum/sirius-parent/assets/2427877/ec50f6ce-0f22-47d4-b70e-1136c54caee3)

**After:**

![image](https://github.com/scireum/sirius-parent/assets/2427877/673dd32a-f00d-40cb-8ad0-bf85587858b0)