### PR TITLE
fix dependency for mocking to make it available in other projects again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
         </dependency>
         <dependency>
             <groupId>io.mockk</groupId>
-            <artifactId>mockk</artifactId>
+            <artifactId>mockk-jvm</artifactId>
             <version>1.13.8</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
https://github.com/mockk/mockk/releases/tag/1.13.1
With this fix, we can use it in DB again and the change in https://github.com/scireum/sirius-db/pull/603/commits/914af2e30d5b63b74a64c3d46a27d9bdb07ed846 is not necessary

- fixes: SIRI-920