### PR TITLE
Roll back to jackson version without deprecation fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -556,7 +556,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.17.0</version>
+                <version>2.16.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
The Jackson maintainers did not understand the difference of the asText() and asText(defaultValue) methods for NullNodes and MissingNodes and deprecated the variant with fallback value. This causes issues:
https://github.com/FasterXML/jackson-databind/issues/4471