### PR TITLE
Try to hint Kotlin to use the current language and API versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,8 @@
         <!-- <sirius.ideaExcludes>.idea/copyright/**</sirius.ideaExcludes> -->
 
         <kotlin.version>2.1.0</kotlin.version>
+        <kotlin.compiler.languageVersion>2.1</kotlin.compiler.languageVersion>
+        <kotlin.compiler.apiVersion>2.1</kotlin.compiler.apiVersion>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlin.compiler.jvmTarget>23</kotlin.compiler.jvmTarget>
     </properties>

--- a/src/main/resources/.idea/kotlinc.xml
+++ b/src/main/resources/.idea/kotlinc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinCommonCompilerArguments">
-    <option name="languageVersion" value="1.9" />
-    <option name="apiVersion" value="1.9" />
+    <option name="languageVersion" value="2.1" />
+    <option name="apiVersion" value="2.1" />
   </component>
 </project>


### PR DESCRIPTION
We had the case where in one product repository the kotlin module was stuck at the deprecated 1.6 API version which would produce build warnings about experimental std lib api usage. This should hopefully set the correct settings after syncing the project via `mvn clean compile`.

Fixes: SIRI-1030