### PR TITLE
Adds some more kotlin configuration

### DIFF
--- a/src/main/resources/.idea/kotlinc.xml
+++ b/src/main/resources/.idea/kotlinc.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinCommonCompilerArguments">
-    <option name="languageVersion" value="2.1" />
     <option name="apiVersion" value="2.1" />
+    <option name="languageVersion" value="2.1" />
+  </component>
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="2.1.0" />
   </component>
 </project>


### PR DESCRIPTION
- without that, intellij would use the bundled kotlin version that isn't java23 ready yet

Fixes: SIRI-1059