### PR TITLE
Updates libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,6 +474,7 @@
         </plugins>
         <extensions>
             <!-- Enabling the use of FTP -->
+            <!-- Current Release: https://maven.apache.org/wagon/wagon-providers/wagon-ftp/summary.html -->
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-ftp</artifactId>
@@ -517,14 +518,16 @@
             <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Changelog: https://github.com/mockk/mockk/releases -->
         <dependency>
             <groupId>io.mockk</groupId>
             <artifactId>mockk-jvm</artifactId>
-            <version>1.14.4</version>
+            <version>1.14.6</version>
             <scope>test</scope>
         </dependency>
 
-        <!-- For legacy junit4 and scenario support. Include JUNIT-Toolbox for testing -->
+        <!-- For legacy junit4 and scenario support. Include JUNIT-Toolbox for testing
+             We want to get rid of junit4, and so we simply freeze this version -->
         <dependency>
             <groupId>com.googlecode.junit-toolbox</groupId>
             <artifactId>junit-toolbox</artifactId>
@@ -532,7 +535,8 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Include Spock for testing -->
+        <!-- Include Spock for testing
+             We want to get rid of junit4, and so we simply freeze this version -->
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
@@ -540,7 +544,8 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Include bytebuddy and objenesis for advanced mocking at spockframework -->
+        <!-- Include bytebuddy and objenesis for advanced mocking at spockframework
+             We want to get rid of junit4, and so we simply freeze this version -->
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
@@ -561,15 +566,15 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.13.4</version>
+                <version>6.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <!-- Release notes: https://github.com/FasterXML/jackson/wiki/Jackson-Releases -->
             <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
+                <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.19.1</version>
+                <version>3.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,9 @@
         
         <plugin.maven-deploy-plugin.version>3.1.4</plugin.maven-deploy-plugin.version>
         <plugin.maven-assembly-plugin.version>3.7.1</plugin.maven-assembly-plugin.version>
-        <plugin.maven-dependency-plugin.version>3.8.1</plugin.maven-dependency-plugin.version>
+        <plugin.maven-dependency-plugin.version>3.9.0</plugin.maven-dependency-plugin.version>
 
-        <kotlin.version>2.2.0</kotlin.version>
+        <kotlin.version>2.2.20</kotlin.version>
         <kotlin.compiler.languageVersion>2.2</kotlin.compiler.languageVersion>
         <kotlin.compiler.apiVersion>2.2</kotlin.compiler.apiVersion>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,11 @@
         <!-- By default, we update the copyright to the sirius/scireum text -->
         <!-- As "real" companies also use this parent, the following can be set to exclude the enforces copyright -->
         <!-- <sirius.ideaExcludes>.idea/copyright/**</sirius.ideaExcludes> -->
-        
+
+        <!-- Overview of all Maven Plugin versions: https://maven.apache.org/plugins/index.html
+             also valid for other plugins defined down below in this file,
+             recognizable by the groupId org.apache.maven.* -->
+
         <plugin.maven-deploy-plugin.version>3.1.4</plugin.maven-deploy-plugin.version>
         <plugin.maven-assembly-plugin.version>3.7.1</plugin.maven-assembly-plugin.version>
         <plugin.maven-dependency-plugin.version>3.9.0</plugin.maven-dependency-plugin.version>
@@ -200,7 +204,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.14.0</version>
+                        <version>3.14.1</version>
                         <configuration>
                             <fork>true</fork>
                             <release>${maven.compiler.release}</release>

--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
             </build>
         </profile>
 
-        <!-- This is exlusively used to create the resources jar for the parent pom. -->
+        <!-- This is exclusively used to create the resources jar for the parent pom. -->
         <profile>
             <id>build-parent</id>
             <activation>
@@ -536,7 +536,7 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.17.2</version>
+            <version>1.17.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -553,7 +553,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.13.3</version>
+                <version>5.13.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,8 @@
         <plugin.maven-assembly-plugin.version>3.7.1</plugin.maven-assembly-plugin.version>
         <plugin.maven-dependency-plugin.version>3.9.0</plugin.maven-dependency-plugin.version>
 
+        <!-- The current version of Kotlin Maven Plugin and its setup can be seen here:
+             https://kotlinlang.org/docs/maven.html -->
         <kotlin.version>2.2.20</kotlin.version>
         <kotlin.compiler.languageVersion>2.2</kotlin.compiler.languageVersion>
         <kotlin.compiler.apiVersion>2.2</kotlin.compiler.apiVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -566,7 +566,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>6.0.0</version>
+                <version>5.14.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.5.2</version>
+                        <version>3.5.4</version>
                         <configuration>
                             <groups>${test.included.groups}</groups>
                             <excludedGroups>${test.excluded.groups}</excludedGroups>
@@ -170,6 +170,7 @@
                     </plugin>
 
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
                         <version>3.1.0</version>
                         <executions>
@@ -197,6 +198,7 @@
                     </plugin>
 
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>3.14.0</version>
                         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
 
         <!-- The current version of Kotlin Maven Plugin and its setup can be seen here:
              https://kotlinlang.org/docs/maven.html -->
+        <!-- Make sure to replicate change done here in src/main/resources/.idea/kotlinc.xml -->
         <kotlin.version>2.2.20</kotlin.version>
         <kotlin.compiler.languageVersion>2.2</kotlin.compiler.languageVersion>
         <kotlin.compiler.apiVersion>2.2</kotlin.compiler.apiVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -572,9 +572,9 @@
             </dependency>
             <!-- Release notes: https://github.com/FasterXML/jackson/wiki/Jackson-Releases -->
             <dependency>
-                <groupId>tools.jackson</groupId>
+                <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>3.0.0</version>
+                <version>2.20.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/resources/.idea/kotlinc.xml
+++ b/src/main/resources/.idea/kotlinc.xml
@@ -5,6 +5,6 @@
     <option name="languageVersion" value="2.2" />
   </component>
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.2.0" />
+    <option name="version" value="2.2.20" />
   </component>
 </project>


### PR DESCRIPTION
There are new major versions for junit (6.0.0) and jackson (3.0.0), but we are skipping them for now.
Jackson ist still incomplete (sub modules in RC) and first tests with junit shows it to be breaking.

We must tackle those at a later point.

Fixes: SIRI-1146