### PR TITLE
Remove support for legacy jUnit 4 Spock Groovy tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,34 +178,6 @@
 
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <version>3.2.0</version>
-                        <executions>
-                            <execution>
-                                <id>groovyc</id>
-                                <phase>test-compile</phase>
-                                <configuration>
-                                    <target>
-                                        <taskdef name="groovyc" classname="org.codehaus.groovy.ant.Groovyc">
-                                            <classpath refid="maven.test.classpath"/>
-                                        </taskdef>
-                                        <mkdir dir="${project.build.testOutputDirectory}"/>
-                                        <groovyc srcdir="${basedir}/src/test/java"
-                                                 destdir="${project.build.testOutputDirectory}"
-                                                 encoding="${project.build.sourceEncoding}">
-                                            <classpath refid="maven.test.classpath"/>
-                                        </groovyc>
-                                    </target>
-                                </configuration>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>3.15.0</version>
                         <configuration>
@@ -497,11 +469,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
@@ -515,7 +482,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test-junit5</artifactId>
             <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
@@ -524,39 +491,6 @@
             <groupId>io.mockk</groupId>
             <artifactId>mockk-jvm</artifactId>
             <version>1.14.9</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- For legacy junit4 and scenario support. Include JUNIT-Toolbox for testing
-             We want to get rid of junit4, and so we simply freeze this version -->
-        <dependency>
-            <groupId>com.googlecode.junit-toolbox</groupId>
-            <artifactId>junit-toolbox</artifactId>
-            <version>2.4</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Include Spock for testing
-             We want to get rid of junit4, and so we simply freeze this version -->
-        <dependency>
-            <groupId>org.spockframework</groupId>
-            <artifactId>spock-core</artifactId>
-            <version>1.3-groovy-2.4</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Include bytebuddy and objenesis for advanced mocking at spockframework
-             We want to get rid of junit4, and so we simply freeze this version -->
-        <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-            <version>1.18.8</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.objenesis</groupId>
-            <artifactId>objenesis</artifactId>
-            <version>3.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## BREAKING CHANGE

- All unit tests written in Groovy with Spock need to be migrated to Kotlin or Java

## Details

All tests have been migrated to jUnit 5 Kotlin or Java