### PR TITLE
Removes not required docker socket from Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,5 @@
 ---
 scireum_volumes: &scireum_volumes
-  - name: docker_socket
-    path: /var/run/docker.sock
   - name: m2
     path: /root/.m2
 
@@ -44,9 +42,6 @@ steps:
         - tag
 
 volumes:
-  - name: docker_socket
-    host:
-      path: /var/run/docker.sock
   - name: m2
     host:
       path: /root/.m2


### PR DESCRIPTION
- sirius-parent does not get build into a docker image