### PR TITLE
Upgrade jackson from 2.22.0 to 3.2.0

### DIFF
--- a/.run/local install.run.xml
+++ b/.run/local install.run.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Made with all the love in the world
+  ~ by scireum in Stuttgart, Germany
+  ~
+  ~ Copyright by scireum GmbH
+  ~ https://www.scireum.de - info@scireum.de
+  -->
+
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="local install" type="MavenRunConfiguration" factoryName="Maven">
+    <MavenSettings>
+      <option name="myGeneralSettings" />
+      <option name="myRunnerSettings" />
+      <option name="myRunnerParameters">
+        <MavenRunnerParameters>
+          <option name="profiles">
+            <set />
+          </option>
+          <option name="goals">
+            <list>
+              <option value="-DskipTests" />
+              <option value="test-compile" />
+              <option value="jar:test-jar" />
+              <option value="install" />
+            </list>
+          </option>
+          <option name="pomFileName" value="pom.xml" />
+          <option name="profilesMap">
+            <map />
+          </option>
+          <option name="resolveToWorkspace" value="false" />
+          <option name="workingDirPath" value="$PROJECT_DIR$" />
+        </MavenRunnerParameters>
+      </option>
+    </MavenSettings>
+    <method v="2" />
+  </configuration>
+</component>

--- a/pom.xml
+++ b/pom.xml
@@ -507,9 +507,9 @@
             </dependency>
             <!-- Release notes: https://github.com/FasterXML/jackson/wiki/Jackson-Releases -->
             <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
+                <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.22.0</version>
+                <version>3.2.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
### BREAKING CHANGES

Upgrades Jackson from 2.22.0 to 3.2.0 across the sirius stack. Jackson 3 uses new Maven coordinates and Java packages — see the official [Jackson 3 migration guide](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md) and [release notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0) for the complete list of renames and behavioral changes.

What applications using the sirius framework have to change:

- Rename imports `com.fasterxml.jackson.*` → `tools.jackson.*` (annotations stay on `com.fasterxml.jackson.annotation`); drop `jackson-datatype-jsr310` and `JavaTimeModule` registrations (built-in now).
- Fix the resulting compile errors: unchecked exceptions (`JsonProcessingException` → `JacksonException`, dead `catch (IOException)` blocks), method renames (`asText()` → `asString()` etc., `writeFieldName()` → `writeName()` etc.), builder-based mapper/generator configuration — see the migration guide for details.
- ⚠️ Not in the migration guide: node accessors (`stringValue()`, `longValue()`, `asString()`, …) now **throw** `JsonNodeException` for missing or mismatched values instead of returning `null`/`0`/`""` like their Jackson 2 counterparts (`textValue()`, `longValue()`, `asText()`). This compiles fine but fails at runtime, e.g. for `node.path("optionalField").stringValue()`. Where the old leniency was relied on, switch to the default-taking variants (`stringValue(null)`, `longValue(0L)`, …) or the `Optional` variants (`stringValueOpt()`, …).

---

Fixes: SIRI-1149
